### PR TITLE
fix Int32 random method generation with passed range into it

### DIFF
--- a/SwiftRandom/Randoms.swift
+++ b/SwiftRandom/Randoms.swift
@@ -40,7 +40,7 @@ public extension Int {
 public extension Int32 {
     /// SwiftRandom extension
     public static func random(_ range: Range<Int>) -> Int32 {
-        return random(range.upperBound, range.lowerBound)
+        return random(range.lowerBound, range.upperBound)
     }
 
     /// SwiftRandom extension

--- a/SwiftRandomTests/SwiftRandomTests.swift
+++ b/SwiftRandomTests/SwiftRandomTests.swift
@@ -33,6 +33,7 @@ class SwiftRandomTests: XCTestCase {
     /// Tests for extensions applied directly above Swift types.
     func testTypeExtensions() {
         XCTAssertNotNil(Int.random())
+        XCTAssertNotNil(Int32.random())
         XCTAssertNotNil(Date.random())
         XCTAssertNotNil(Date.randomWithinDaysBeforeToday(7))
         XCTAssertNotNil(CGFloat.random())
@@ -66,7 +67,17 @@ class SwiftRandomTests: XCTestCase {
             XCTAssertLessThan(randomLessTen, 10)
         }
     }
-	
+
+    func testRandomInt32Range() {
+        for _ in 0...10 {
+
+            let randomLessTen = Int32.random(0..<10)
+
+            XCTAssertGreaterThanOrEqual(randomLessTen, Int32(0))
+            XCTAssertLessThan(randomLessTen, Int32(10))
+        }
+    }
+
     /// Tests generating random a `String` of a specified length.
     func testRandomStringOfLength() {
         let precision = 100


### PR DESCRIPTION
Upper bond cannot be less the lower bond. Added unit tests as well. 